### PR TITLE
chore: move OpenAPI adjustments from Makefile to CI workflow

### DIFF
--- a/.github/workflows/api-docs-update-v2.yaml
+++ b/.github/workflows/api-docs-update-v2.yaml
@@ -12,12 +12,28 @@ jobs:
   api-docs-update-trigger:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Apply OpenAPI adjustments
+        run: |
+          cd protobuff
+          cp qubic.openapi.yaml qubic.openapi.adjusted.yaml
+          yq -i '(.tags[] | select(.name == "QubicLiveService")).x-scalar-ignore = true' qubic.openapi.adjusted.yaml
+
+      - name: Encode adjusted spec
+        id: encode
+        run: |
+          CONTENT=$(base64 -w 0 protobuff/qubic.openapi.adjusted.yaml)
+          echo "spec_base64=$CONTENT" >> "$GITHUB_OUTPUT"
+
       - name: Dispatch to Integration
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.GH_PAT }}
           repository: qubic/integration
-          event-type: api-docs-update
+          event-type: live-api-update
+          client-payload: '{"openapi_spec_base64": "${{ steps.encode.outputs.spec_base64 }}"}'
 
       - name: Dispatch to Docs
         uses: peter-evans/repository-dispatch@v3
@@ -25,3 +41,4 @@ jobs:
           token: ${{ secrets.GH_PAT }}
           repository: qubic/docs
           event-type: live-api-update
+          client-payload: '{"openapi_spec_base64": "${{ steps.encode.outputs.spec_base64 }}"}'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,3 +23,27 @@ jobs:
         with:
           go-version: 1.25.x
       - run: go test ./...
+
+  check-openapi:
+    name: Check OpenAPI spec is up to date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.25.x
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: '28.x'
+      - name: Install protoc-gen-openapi
+        run: go install github.com/google/gnostic/cmd/protoc-gen-openapi@latest
+      - name: Regenerate OpenAPI spec
+        working-directory: protobuff
+        run: make openapi-v3
+      - name: Check for differences
+        run: |
+          if ! git diff --exit-code protobuff/qubic.openapi.yaml; then
+            echo "::error::OpenAPI spec is out of date. Run 'make openapi-v3' in protobuff/ and commit the result."
+            exit 1
+          fi

--- a/protobuff/Makefile
+++ b/protobuff/Makefile
@@ -33,8 +33,6 @@ all: $(GO) openapi-v3
 
 openapi-v3:
 		protoc -I=. --openapi_out=output_mode=source_relative,default_response=false:. *.proto
-		@# Add x-scalar-ignore to auto-generated QubicLiveService tag
-		yq -i '(.tags[] | select(.name == "QubicLiveService")).x-scalar-ignore = true' qubic.openapi.yaml
 
 clean:
 		rm -f *.pb.go


### PR DESCRIPTION
Move yq post-processing (x-scalar-ignore on QubicLiveService) from the Makefile to the GitHub Actions workflow. The Makefile now generates raw protoc output, and adjustments are applied on-the-fly before dispatching the base64-encoded spec to consumer repos (integration, docs).