### PR TITLE
fix: dispatch commit SHA instead of inlined OpenAPI spec

### DIFF
--- a/.github/workflows/api-docs-update-v2.yaml
+++ b/.github/workflows/api-docs-update-v2.yaml
@@ -6,22 +6,24 @@ on:
     branches:
       - main
     paths:
-      - 'protobuff/qubic.openapi.yaml' # Only trigger if the OpenAPI file changed
+      - 'protobuff/*.proto'
 
 jobs:
   api-docs-update-trigger:
     runs-on: ubuntu-latest
     steps:
-      - name: Dispatch to Integration
+      - name: Dispatch to qubic/integration
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.GH_PAT }}
           repository: qubic/integration
-          event-type: api-docs-update
+          event-type: live-api-update
+          client-payload: '{"ref": "${{ github.sha }}"}'
 
-      - name: Dispatch to Docs
+      - name: Dispatch to qubic/docs
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.GH_PAT }}
           repository: qubic/docs
           event-type: live-api-update
+          client-payload: '{"ref": "${{ github.sha }}"}'

--- a/protobuff/Makefile
+++ b/protobuff/Makefile
@@ -33,8 +33,6 @@ all: $(GO) openapi-v3
 
 openapi-v3:
 		protoc -I=. --openapi_out=output_mode=source_relative,default_response=false:. *.proto
-		@# Add x-scalar-ignore to auto-generated QubicLiveService tag
-		yq -i '(.tags[] | select(.name == "QubicLiveService")).x-scalar-ignore = true' qubic.openapi.yaml
 
 clean:
 		rm -f *.pb.go


### PR DESCRIPTION
The base64-encoded OpenAPI spec exceeds GitHub's 65535-character client_payload limit. Send the commit SHA instead so receiving repositories can check out this repo and generate the spec themselves.